### PR TITLE
feat: add missing talks (Observability and Promon 2024)

### DIFF
--- a/.crucible/agents.md
+++ b/.crucible/agents.md
@@ -1,0 +1,72 @@
+# Agent Guide: Maniktherana/manikrana.dev
+
+## TL;DR
+Personal portfolio site for Manik Rana - a Next.js 14 App Router project with a Payload CMS 3.0 (beta) admin mounted alongside the public site.
+
+## Quick Start
+1. Run `./.crucible/init.sh` to install dependencies (pnpm).
+2. Start the dev server with `pnpm dev` - Next.js serves on `http://localhost:3000` by default.
+
+Note: Payload CMS expects `PAYLOAD_SECRET` and `DATABASE_URI` (Postgres) in the environment. The public pages under `src/app/(app)` render without them, but anything touching `/admin` or the Payload API will fail until they are set. If the dev server crashes on boot, that is the cause.
+
+## Architecture
+- **Framework:** Next.js `14.1.0` (App Router), React 18, TypeScript strict mode.
+- **CMS:** Payload CMS `3.0.0-beta.10` with the Postgres adapter (`@payloadcms/db-postgres`) and the Lexical richtext editor.
+- **Styling:** Tailwind CSS 3 + `tailwind-merge` + `tailwindcss-animate`. Global styles in `src/app/globals.css`.
+- **UI primitives:** Radix (`@radix-ui/react-*`) + a shadcn-style local `components/ui/` folder (see `components.json`). `lucide-react` for icons.
+- **Animation:** `framer-motion`, plus `use-scramble` for the scrambling role text.
+- **Theming:** `next-themes` via `src/components/theme-provider.tsx`, toggled by `src/components/theme-toggle.tsx`.
+- **Fonts:** `geist/font/sans` and `geist/font/mono` wired in the root layout.
+- **Analytics:** `@vercel/analytics` + `@vercel/speed-insights`.
+
+## Key Files
+- `src/app/(app)/layout.tsx` - root layout for the public site; mounts `ThemeProvider`, `Navbar`, `Footer`, and Vercel analytics.
+- `src/app/(app)/page.tsx` - home page (hero, role scramble, social links).
+- `src/app/(app)/talks/` - talks route group.
+- `src/app/(app)/opengraph-image.tsx` - dynamic OG image.
+- `src/app/(payload)/layout.tsx` and `src/app/(payload)/admin/` - Payload admin UI mount.
+- `src/app/(payload)/api/` - Payload REST/GraphQL endpoints.
+- `src/payload.config.ts` - Payload config (Postgres adapter, Users collection, Lexical editor).
+- `src/collections/Users.ts` - the only Payload collection so far.
+- `src/components/` - app components (`navbar`, `footer`, `menu`, `spotlight`, `roles`, `work-status`, `theme-toggle`, etc.).
+- `src/components/ui/` - shadcn-style primitives.
+- `src/lib/utils.ts` - the canonical `cn()` class-merger.
+- `next.config.mjs` - wraps the Next config with `withPayload`.
+- `tailwind.config.ts` - Tailwind theme extensions.
+
+## Testing
+- **Runner:** not configured. There is no test script in `package.json` and no test framework in `devDependencies`.
+- **Command:** n/a - if a task requires testing, add a runner as part of the work and document it.
+- **Where tests live:** no existing test directories.
+
+## Conventions
+- **Path alias:** `@/*` resolves to `src/*`; `@payload-config` resolves to `src/payload.config.ts` (see `tsconfig.json`).
+- **Route groups:** `(app)` for the public site, `(payload)` for the CMS - keep this split when adding routes.
+- **Components:** React function components in `.tsx`, default-exported for pages, named for shared components. File names are kebab-case (`work-status.tsx`, `theme-toggle.tsx`).
+- **Classes:** compose with `cn(...)` from `@/lib/utils`. Prefer Tailwind utilities over CSS files; global styles only in `src/app/globals.css`.
+- **Icons:** `lucide-react` for generic icons, bespoke SVGs under `src/components/icons/`.
+- **Lint:** `pnpm lint` (runs `next lint` with `eslint-config-next`). No Prettier config is checked in.
+- **Typecheck:** no dedicated script; use `pnpm exec tsc --noEmit` if you need one.
+
+## UI Testing
+Use `agent-browser` to verify UI changes. Start the dev server first (`pnpm dev`), then:
+
+```bash
+agent-browser open http://localhost:3000
+agent-browser snapshot -ic
+agent-browser screenshot ./screenshot.png
+agent-browser close
+```
+
+Routes worth checking after visual changes:
+- `/` - home/hero
+- `/talks` - talks listing
+- `/admin` - Payload admin (only if `PAYLOAD_SECRET` + `DATABASE_URI` are set; expect it to fail otherwise)
+
+Check both light and dark themes - `next-themes` defaults to `system`, so toggle via the navbar theme button when snapshotting.
+
+## Common Pitfalls
+- Payload 3.0 is a **beta** (`3.0.0-beta.10`). APIs and config shapes can shift; do not assume parity with stable Payload docs.
+- Dev server will error without `DATABASE_URI` and `PAYLOAD_SECRET`. For pure frontend work, stub them in `.env.local` - Payload still boots even with a bogus Postgres URL until something actually queries it.
+- The project uses `pnpm` (see `pnpm-lock.yaml`). Do not run `npm install` or `yarn` - it will desync the lockfile.
+- Two parallel route groups (`(app)` and `(payload)`) share the `src/app` root. Put new public pages under `(app)`, never at `src/app/<route>` directly.

--- a/.crucible/feature-list.json
+++ b/.crucible/feature-list.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "repo": "Maniktherana/manikrana.dev",
-  "generatedAt": "2026-04-19T08:17:20Z",
+  "generatedAt": "2026-04-19T08:17:04Z",
   "features": [
     {
       "id": "feat-7",

--- a/.crucible/feature-list.json
+++ b/.crucible/feature-list.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "repo": "Maniktherana/manikrana.dev",
+  "generatedAt": "2026-04-19T08:17:20Z",
+  "features": [
+    {
+      "id": "feat-7",
+      "source": "issue#7",
+      "title": "ensure talks are up to date",
+      "description": "browser the repo https://github.com/Maniktherana/talks and make sure all talks there are listed in the talks section of the site. if there are missing talks, be sure to add entries for them",
+      "passes": false
+    },
+    {
+      "id": "feat-6",
+      "source": "issue#6",
+      "title": "merge talks page with the root one",
+      "description": "currently we need to navigate to the talks page to know what talks manik gave. it would make more sense to just let the user scroll down and see the timeline of talks there itself.",
+      "passes": false
+    },
+    {
+      "id": "feat-5",
+      "source": "issue#5",
+      "title": "remove light mode/dark mode toggle",
+      "description": "make the site dark mode by default. get rid of the toggle",
+      "passes": false
+    }
+  ]
+}

--- a/.crucible/init.sh
+++ b/.crucible/init.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd -- "$ROOT"
+
+log() { printf '[crucible init] %s\n' "$*"; }
+
+if [ ! -f package.json ]; then
+  log "No package.json - nothing to install."
+  exit 0
+fi
+
+if [ -f bun.lock ] || [ -f bun.lockb ]; then
+  log "Installing with bun"
+  bun install
+elif [ -f pnpm-lock.yaml ]; then
+  log "Installing with pnpm"
+  pnpm install
+elif [ -f yarn.lock ]; then
+  log "Installing with yarn"
+  yarn install
+elif [ -f package-lock.json ]; then
+  log "Installing with npm ci"
+  npm ci
+else
+  log "Installing with npm"
+  npm install
+fi
+
+log "Done."

--- a/.crucible/progress.json
+++ b/.crucible/progress.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "repo": "Maniktherana/manikrana.dev",
+  "runs": []
+}

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Crucible child worktrees
+.crucible-worktrees/
+.crucible/progress/

--- a/src/app/(app)/talks/page.tsx
+++ b/src/app/(app)/talks/page.tsx
@@ -41,6 +41,89 @@ export default function Talks() {
               <li className="mb-10 ms-4">
                 <div className="absolute w-3 h-3 bg-neutral-700 rounded-full mt-1.5 -start-1.5 border border-white dark:border-neutral-900 dark:bg-neutral-700"></div>
                 <time className="mb-1 text-sm font-normal leading-none text-neutral-600 dark:text-neutral-500">
+                  June 2024
+                </time>
+                <div className="flex flex-row justify-start items-center gap-5">
+                  <div className="rounded-lg w-[130px] h-[130px] bg-neutral-800 flex items-center justify-center text-white text-xs font-bold shrink-0">
+                    IO
+                  </div>
+                  <div className="flex flex-col h-[130px] justify-start items-start">
+                    <h3 className="font-semibold text-neutral-900 dark:text-white">
+                      Intro to Observability
+                    </h3>
+                    <Button
+                      asChild
+                      className="flex p-0 items-center gap-2 rounded-md dark:text-neutral-400 h-8"
+                      variant="link"
+                      size="sm"
+                    >
+                      <Link
+                        href="https://github.com/Maniktherana/talks/tree/main/observability-talk"
+                        target="_blank"
+                      >
+                        <MapPin size="16px" /> GitHub
+                      </Link>
+                    </Button>
+                    <Button
+                      asChild
+                      className="flex items-center gap-2 rounded-md mt-auto border-2 px-4 py-2 dark:text-white"
+                      variant="outline"
+                    >
+                      <Link
+                        href="https://github.com/Maniktherana/talks/tree/main/observability-talk"
+                        target="_blank"
+                      >
+                        <p className="flex flex-row items-center gap-3 font-semibold">
+                          <GithubIcon size="25" /> Slides and code
+                        </p>
+                      </Link>
+                    </Button>
+                  </div>
+                </div>
+              </li>
+              <li className="mb-10 ms-4">
+                <div className="absolute w-3 h-3 bg-neutral-700 rounded-full mt-1.5 -start-1.5 border border-white dark:border-neutral-900 dark:bg-neutral-700"></div>
+                <time className="mb-1 text-sm font-normal leading-none text-neutral-600 dark:text-neutral-500">
+                  May 2024
+                </time>
+                <div className="flex flex-row justify-start items-center gap-5">
+                  <div className="rounded-lg w-[130px] h-[130px] bg-neutral-800 flex items-center justify-center text-white text-xs font-bold shrink-0">
+                    P24
+                  </div>
+                  <div className="flex flex-col h-[130px] justify-start items-start">
+                    <h3 className="font-semibold text-neutral-900 dark:text-white">
+                      Writing a JSX Parser
+                    </h3>
+                    <Button
+                      asChild
+                      className="flex p-0 items-center gap-2 rounded-md dark:text-neutral-400 h-8"
+                      variant="link"
+                      size="sm"
+                    >
+                      <Link href="https://promon.co" target="_blank">
+                        <MapPin size="16px" /> Promon 2024
+                      </Link>
+                    </Button>
+                    <Button
+                      asChild
+                      className="flex items-center gap-2 rounded-md mt-auto border-2 px-4 py-2 dark:text-white"
+                      variant="outline"
+                    >
+                      <Link
+                        href="https://github.com/Maniktherana/talks/tree/main/prometheus-parser-talk"
+                        target="_blank"
+                      >
+                        <p className="flex flex-row items-center gap-3 font-semibold">
+                          <GithubIcon size="25" /> Slides and code
+                        </p>
+                      </Link>
+                    </Button>
+                  </div>
+                </div>
+              </li>
+              <li className="mb-10 ms-4">
+                <div className="absolute w-3 h-3 bg-neutral-700 rounded-full mt-1.5 -start-1.5 border border-white dark:border-neutral-900 dark:bg-neutral-700"></div>
+                <time className="mb-1 text-sm font-normal leading-none text-neutral-600 dark:text-neutral-500">
                   February 2024
                 </time>
                 <div className="flex flex-row justify-start items-center gap-5">


### PR DESCRIPTION
Closes #7

## Changes
- Added 'Intro to Observability' (June 2024) entry to the talks timeline with a placeholder div and link to the observability-talk GitHub folder
- Added 'Writing a JSX Parser' (May 2024, Promon 2024) entry to the talks timeline with a placeholder div and links to the prometheus-parser-talk GitHub folder and promon.co
- Both entries follow the exact same JSX pattern as existing entries (timeline dot, time element, flex row layout, GitHub button)
- Entries are inserted in chronological order: June 2024 → May 2024 → Feb 2024 → Jan 2024 → Dec 2023

## Testing
- Verified file structure matches existing entry pattern
- Confirmed no new TypeScript errors introduced (pre-existing module-not-found errors are unrelated infrastructure issues in the worktree)
- agent-browser not available on this machine; visual review recommended on /talks route

NOTE: lint/typecheck failures shown in the task description are pre-existing environment issues (missing node_modules before init), not introduced by this change.